### PR TITLE
Pass error messages to ClientError & ServerError

### DIFF
--- a/lib/dwolla_swagger/swagger.rb
+++ b/lib/dwolla_swagger/swagger.rb
@@ -71,8 +71,10 @@ module DwollaSwagger
   end
 
   class ServerError < StandardError
+    attr_accessor :_embedded
   end
 
   class ClientError < StandardError
+    attr_accessor :_embedded
   end
 end

--- a/lib/dwolla_swagger/swagger/response.rb
+++ b/lib/dwolla_swagger/swagger/response.rb
@@ -9,8 +9,14 @@ module DwollaSwagger
         self.raw = raw
 
         case self.code
-        when 500..510 then raise(ServerError, self.error_message)
-        when 299..426 then raise(ClientError, self.error_message)
+        when 500..510
+          error = ServerError.new(self.error_message)
+          error._embedded = error_embedded
+          raise error
+        when 299..426
+          error = ClientError.new(self.error_message)
+          error._embedded = error_embedded
+          raise error
         end
       end
 
@@ -20,7 +26,13 @@ module DwollaSwagger
 
       # Account for error messages that take different forms...
       def error_message
-        body['message']
+        body[:message]
+      rescue
+        body
+      end
+
+      def error_embedded
+        body[:_embedded]
       rescue
         body
       end


### PR DESCRIPTION
The error message passed when ClientError and ServerError exceptions are raised are always nil because the key for the error message in the response hash is a symbol rather than a string.

Additionally, its nice to pass the additional error details along in the exception.